### PR TITLE
Support intra-page URL fragment identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.bowerrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.bowerrc

--- a/core-doc-viewer.html
+++ b/core-doc-viewer.html
@@ -147,7 +147,11 @@ Arbitrary HTML is also supported
       validateRoute: function() {
         if (this.route) {
           this.classes.some(function(c) {
-            if (c.name === this.route) {
+            // The URL fragment might be just a class name,
+            // or it might be a class name followed by a '.' and then
+            // a section of the the page.
+            // We want to match on class names here, so split on '.'.
+            if (c.name === this.route.split('.')[0]) {
               this.data = c;
               this.route = '';
               return;

--- a/core-doc-viewer.html
+++ b/core-doc-viewer.html
@@ -149,7 +149,7 @@ Arbitrary HTML is also supported
           this.classes.some(function(c) {
             // The URL fragment might be just a class name,
             // or it might be a class name followed by a '.' and then
-            // a section of the the page.
+            // a section of the page.
             // We want to match on class names here, so split on '.'.
             // E.g.: 'core-ajax.properties.xhrArgs' -> 'core-ajax'
             //       'core-xhr' -> 'core-xhr'

--- a/core-doc-viewer.html
+++ b/core-doc-viewer.html
@@ -151,6 +151,8 @@ Arbitrary HTML is also supported
             // or it might be a class name followed by a '.' and then
             // a section of the the page.
             // We want to match on class names here, so split on '.'.
+            // E.g.: 'core-ajax.properties.xhrArgs' -> 'core-ajax'
+            //       'core-xhr' -> 'core-xhr'
             if (c.name === this.route.split('.')[0]) {
               this.data = c;
               this.route = '';

--- a/elements/core-doc-page.html
+++ b/elements/core-doc-page.html
@@ -44,30 +44,30 @@ Displays formatted source documentation scraped from input urls.
 
         <template if="{{data.extends}}">
           <section class="top">
-            <h3>Extends: <a href="#{{data.extends}}">{{data.extends}}</a></h3>
+            <h3 id="{{data.name}}.extends">Extends: <a href="#{{data.extends}}">{{data.extends}}</a></h3>
           </section>
         </template>
 
         <template if="{{data.description}}">
           <section class="box top">
-            <h3>Summary</h3>
+            <h3 id="{{data.name}}.summary">Summary</h3>
             <marked-element text="{{data.description}}"></marked-element>
           </section>
         </template>
 
         <template if="{{data.attributes.length}}">
           <section class="box attribute-box">
-            <h3>Attributes</h3>
-            <template repeat="{{data.attributes}}">
+            <h3 id="{{data.name}}.attributes">Attributes</h3>
+            <template repeat="{{attribute in data.attributes}}">
               <div class="details" horizontal layout>
-                <div class="details-name" flex>
-                  <p><code>{{name}}</code></p>
+                <div class="details-name" flex id="{{data.name}}.attributes.{{attribute.name}}">
+                  <p><code>{{attribute.name}}</code></p>
                 </div>
                 <div class="details-info" flex three>
                   <p layout horizontal center justified>
-                    <code>{{type}}</code><span class="default" hidden?="{{!default}}">default: <code>{{default}}</code></span>
+                    <code>{{attribute.type}}</code><span class="default" hidden?="{{!attribute.default}}">default: <code>{{attribute.default}}</code></span>
                   </p>
-                  <marked-element text="{{description}}"></marked-element>
+                  <marked-element text="{{attribute.description}}"></marked-element>
                 </div>
               </div>
             </template>
@@ -76,17 +76,17 @@ Displays formatted source documentation scraped from input urls.
 
         <template if="{{data.properties.length}}">
           <section class="box property-box">
-            <h3>Properties</h3>
-            <template repeat="{{data.properties}}">
+            <h3 id="{{data.name}}.properties">Properties</h3>
+            <template repeat="{{property in data.properties}}">
               <div class="details" horizontal layout>
-                <div class="details-name" flex>
-                  <p><code>{{name}}</code></p>
+                <div class="details-name" flex id="{{data.name}}.properties.{{property.name}}">
+                  <p><code>{{property.name}}</code></p>
                 </div>
                 <div class="details-info" flex three>
                   <p layout horizontal center justified>
-                    <code>{{type}}</code><span class="default" hidden?="{{!default}}">default: <code>{{default}}</code></span>
+                    <code>{{property.type}}</code><span class="default" hidden?="{{!property.default}}">default: <code>{{property.default}}</code></span>
                   </p>
-                  <marked-element text="{{description}}"></marked-element>
+                  <marked-element text="{{property.description}}"></marked-element>
                 </div>
               </div>
             </template>
@@ -95,20 +95,20 @@ Displays formatted source documentation scraped from input urls.
 
         <template if="{{data.events.length}}">
           <section class="box event-box">
-            <h3>Events</h3>
-            <template repeat="{{data.events}}">
+            <h3 id="{{data.name}}.events">Events</h3>
+            <template repeat="{{event in data.events}}">
               <div class="details" horizontal layout>
-                <div class="details-name" flex>
-                  <p><code>{{name}}</code></p>
+                <div class="details-name" flex id="{{data.name}}.events.{{event.name}}">
+                  <p><code>{{event.name}}</code></p>
                 </div>
                 <div class="details-info" flex three>
-                  <marked-element text="{{description}}"></marked-element>
-                  <template if="{{params.length}}">
+                  <marked-element text="{{event.description}}"></marked-element>
+                  <template if="{{event.params.length}}">
                     <div class="params">
                       <p>Event details:</p>
-                      <template repeat="{{params}}">
-                        <p><code>{{name}}</code><span> <code>( {{type}} )</code></span></p>
-                        <p><span>{{description}}</span></p>
+                      <template repeat="{{param in event.params}}">
+                        <p><code>{{param.name}}</code><span> <code>( {{param.type}} )</code></span></p>
+                        <p><span>{{param.description}}</span></p>
                       </template>
                     </div>
                   </template>
@@ -120,20 +120,20 @@ Displays formatted source documentation scraped from input urls.
 
         <template if="{{data.methods.length}}">
           <section class="box method-box">
-            <h3>Methods</h3>
-            <template repeat="{{data.methods}}">
+            <h3 id="{{data.name}}.methods">Methods</h3>
+            <template repeat="{{method in data.methods}}">
               <div class="details" horizontal layout>
-                <div class="details-name" flex>
-                  <p><code>{{name}}</code></p>
+                <div class="details-name" flex id="{{data.name}}.methods.{{method.name}}">
+                  <p><code>{{method.name}}</code></p>
                 </div>
                 <div class="details-info" flex three>
-                  <marked-element text="{{description}}"></marked-element>
-                  <template if="{{params.length}}">
+                  <marked-element text="{{method.description}}"></marked-element>
+                  <template if="{{method.params.length}}">
                     <div class="params">
                       <p>Method parameters:</p>
-                      <template repeat="{{params}}">
-                        <p><code>{{name}}</code><span> <code>( {{type}} )</code></span></p>
-                        <p><span>{{description}}</span></p>
+                      <template repeat="{{param in method.params}}">
+                        <p><code>{{param.name}}</code><span> <code>( {{param.type}} )</code></span></p>
+                        <p><span>{{param.description}}</span></p>
                       </template>
                     </div>
                   </template>
@@ -166,6 +166,17 @@ Displays formatted source documentation scraped from input urls.
         } else {
           return data.homepage;
         }
+      },
+
+      dataChanged: function() {
+        // Wrap in async() to delay execution until the next animation frame,
+        // since the <template> contents won't be stamped at the time this is executed.
+        this.async(function() {
+          var elementToFocus = this.shadowRoot.getElementById(window.location.hash.slice(1));
+          if (elementToFocus) {
+            elementToFocus.scrollIntoView();
+          }
+        });
       }
 
     });


### PR DESCRIPTION
@ebidel @addyosmani & co.:

Allows you to link directly to, e.g., an individual attribute or method in a specific doc page.
Supports `<core-doc-viewer>`s with multiple `sources=` set, or with a single `url=` set.
Maintains compatibility with using class names as the URL fragment identifier to switch between classes when multiple `sources=` is set.

Sample URLs:
- http://jeffposnick.github.io/core-doc-viewer/components/core-doc-viewer/demo.html#core-ajax.properties.xhrArgs
- http://jeffposnick.github.io/core-doc-viewer/components/core-doc-viewer/demo.html#core-icon.attributes
- http://jeffposnick.github.io/core-doc-viewer/components/core-doc-viewer/demo.html#core-icon.summary
- http://jeffposnick.github.io/core-doc-viewer/components/core-doc-viewer/demo.html#core-xhr
