### PR TITLE
Reformatted the type info displayed for method and event parameters

### DIFF
--- a/elements/core-doc-page.html
+++ b/elements/core-doc-page.html
@@ -84,7 +84,7 @@ Displays formatted source documentation scraped from input urls.
                 </div>
                 <div class="details-info" flex three>
                   <p layout horizontal center justified>
-                  <code>&lt;<em>{{property.type}}</em>&gt;</code><span class="default" hidden?="{{!property.default}}">default: <code>{{property.default}}</code></span>
+                    <code>&lt;<em>{{property.type}}</em>&gt;</code><span class="default" hidden?="{{!property.default}}">default: <code>{{property.default}}</code></span>
                   </p>
                   <marked-element text="{{property.description}}"></marked-element>
                 </div>


### PR DESCRIPTION
@ebidel @addyosmani 

Closes #27, with a live example at http://jeffposnick.github.io/core-doc-viewer/components/core-doc-viewer/demo.html#core-xhr.methods.request (and that link makes use of support for intra-page URL fragments!).

I'm happy to switch up the formatting, if you have any strong preferences re: wrapping the type in `<>` vs. something else, using `<em>`, etc.
