### PR TITLE
Scroll to top if data changes

### DIFF
--- a/elements/core-doc-page.html
+++ b/elements/core-doc-page.html
@@ -208,7 +208,7 @@ Displays formatted source documentation scraped from input urls.
             elementToFocus.scrollIntoView();
           }
           else {
-            var viewer = this.shadowRoot.querySelector('core-header-panel').shadowRoot.querySelector('#mainContainer');
+            var viewer = this.$.panel.scroller;
             viewer.scrollTop = 0;
             viewer.scrollLeft = 0;
           }


### PR DESCRIPTION
The problem: 
When reusing core-doc-page for multiple docs, scroll position is preserved when docs change. It is a bad user experience, you end up looking at the middle of a freshly loaded doc.
The fix:
Scroll to top when user data changes.
Question:
Is there a way to do this without traversing core-header-panel's internal structure? Hate doing that...
